### PR TITLE
feat: string indexing functionality

### DIFF
--- a/icg-backend/icg/icg_visitor.py
+++ b/icg-backend/icg/icg_visitor.py
@@ -1049,6 +1049,11 @@ class ICGVisitor:
         
         base_name = name.split("[", 1)[0]
         sym = self._symbol_table.get(base_name, {})
+        if "[" in name:
+            if sym.get("kind") == "array" or sym.get("dims"):
+                return sym.get("dtype", "unknown")
+            if sym.get("dtype") == "string":
+                return "char"
         return sym.get("dtype", "unknown")
     
     def get_table(self) -> IndirectTripleTable:

--- a/icg-backend/icg/runtime_executor.py
+++ b/icg-backend/icg/runtime_executor.py
@@ -741,12 +741,16 @@ class RuntimeExecutor:
             array_name = self._resolve_array_name(array_name)
             index = self._eval(arg2, line, col)
             index_val = unwrap_value(index)
-            key = f"{array_name}[{int(index_val)}]"
-            if key in self._memory:
-                self._results[idx] = self._memory[key]
+            index_int = int(index_val)
+            if self._is_scalar_string_variable(array_name):
+                self._results[idx] = self._read_string_index(array_name, index_int, line, col)
             else:
-                # Return default value with inferred type
-                self._results[idx] = RuntimeValue(0, "int")
+                key = f"{array_name}[{index_int}]"
+                if key in self._memory:
+                    self._results[idx] = self._memory[key]
+                else:
+                    # Return default value with inferred type
+                    self._results[idx] = RuntimeValue(0, "int")
         
         elif op == "array_store":
             # Array element store - handles two formats:
@@ -904,6 +908,8 @@ class RuntimeExecutor:
             if array_match:
                 array_name = array_match.group(1)
                 index = int(array_match.group(2))
+                if self._is_scalar_string_variable(array_name):
+                    return self._read_string_index(array_name, index, line, col)
                 key = f"{array_name}[{index}]"
                 if key in self._memory:
                     val = self._memory[key]
@@ -1081,6 +1087,86 @@ class RuntimeExecutor:
                 break
             array_name = next_name
         return array_name
+
+    def _is_scalar_string_variable(self, var_name: str) -> bool:
+        """Check whether a variable refers to a non-array string value."""
+        sym = self._symbol_table.get(var_name, {})
+        if (
+            sym.get("dtype") == "string"
+            and sym.get("kind") != "array"
+            and not sym.get("dims")
+        ):
+            return True
+
+        value = self._memory.get(var_name)
+        return isinstance(value, RuntimeValue) and value.dtype == "string"
+
+    def _read_string_index(self, var_name: str, index: int, line: int, col: int) -> RuntimeValue:
+        """Read one character from a string variable using array-style indexing."""
+        if index < 0:
+            raise ICGRuntimeError(
+                message=f"String index cannot be negative (got {index})",
+                line=line,
+                col=col,
+                error_type="runtime_error"
+            )
+
+        string_value = self._memory.get(var_name)
+        if isinstance(string_value, RuntimeValue):
+            text = string_value.value if string_value.dtype == "string" else str(string_value.value)
+        else:
+            text = "" if string_value is None else str(string_value)
+
+        if index >= len(text):
+            raise ICGRuntimeError(
+                message=f"String index {index} out of bounds for '{var_name}' (length {len(text)})",
+                line=line,
+                col=col,
+                error_type="runtime_error"
+            )
+
+        return RuntimeValue(text[index], "char")
+
+    def _store_string_index(self, var_name: str, index: int, value: RuntimeValue,
+                            line: int, col: int) -> None:
+        """Store a single character into a string variable for trap(name[index])."""
+        if index < 0:
+            raise ICGRuntimeError(
+                message=f"String index cannot be negative (got {index})",
+                line=line,
+                col=col,
+                error_type="runtime_error"
+            )
+
+        string_value = self._memory.get(var_name)
+        if isinstance(string_value, RuntimeValue):
+            text = string_value.value if string_value.dtype == "string" else str(string_value.value)
+        else:
+            text = "" if string_value is None else str(string_value)
+
+        char_value = unwrap_value(value)
+        if len(char_value) != 1:
+            raise ICGRuntimeError(
+                message="Expected single character",
+                line=line,
+                col=col,
+                error_type="runtime_error"
+            )
+
+        if index > len(text):
+            raise ICGRuntimeError(
+                message=f"String index {index} out of bounds for '{var_name}' (length {len(text)})",
+                line=line,
+                col=col,
+                error_type="runtime_error"
+            )
+
+        if index == len(text):
+            new_text = text + char_value
+        else:
+            new_text = text[:index] + char_value + text[index + 1:]
+
+        self._memory[var_name] = RuntimeValue(new_text, "string")
 
     def _collect_preserved_array_elements(self) -> Dict[str, Any]:
         """Capture array elements that must survive a function return."""
@@ -1344,12 +1430,18 @@ class RuntimeExecutor:
         # Parse array element syntax: arr[index]
         array_match = re.match(r'^(\w+)\[(.+)\]$', var_name)
         actual_var_name = var_name
+        string_target: Optional[Tuple[str, int]] = None
         
         if array_match:
-            array_name = self._resolve_array_name(array_match.group(1))
+            base_name = array_match.group(1)
+            array_name = self._resolve_array_name(base_name)
             index_expr = array_match.group(2).strip()
             index_value = unwrap_value(self._eval(index_expr, line, col))
-            actual_var_name = f"{array_name}[{int(index_value)}]"
+            index_int = int(index_value)
+            if self._is_scalar_string_variable(base_name) or self._is_scalar_string_variable(array_name):
+                string_target = (array_name, index_int)
+            else:
+                actual_var_name = f"{array_name}[{index_int}]"
         
         # Request input from handler
         raw_input = self._input_handler.request_input(var_name, var_type, line, col)
@@ -1416,7 +1508,11 @@ class RuntimeExecutor:
                     value = RuntimeValue(raw_input, "string")
             
             # Store in memory
-            self._memory[actual_var_name] = value
+            if string_target is not None:
+                string_name, string_index = string_target
+                self._store_string_index(string_name, string_index, value, line, col)
+            else:
+                self._memory[actual_var_name] = value
             
         except ValueError as e:
             raise ICGRuntimeError(

--- a/portia-mps/simple-string_indexing.portia
+++ b/portia-mps/simple-string_indexing.portia
@@ -1,0 +1,20 @@
+int main() {
+  local var string word = "";
+  local var int len = 0;
+  local var int i = 0;
+
+  thread("Enter a word: ");
+  trap(word);
+
+  thread("Enter its length: ");
+  trap(len);
+
+  for (i = 0; i < len; i += 1) {
+    thread("Character at index ");
+    thread(i);
+    thread(": ");
+    threadln(word[i]);
+  }
+
+  return 0;
+}

--- a/portia-mps/simple-valid_username.portia
+++ b/portia-mps/simple-valid_username.portia
@@ -1,0 +1,108 @@
+/*
+Write a program that prompts the user to input a username. Use a loop to keep asking for a 
+username until a valid one is entered (e.g., at least 8 characters long, with at least one capital letter 
+and at least one special character, combination of letter(capital/small, number, special character).
+*/
+
+// Returns true if c is an uppercase letter (A-Z)
+func bool isUpper(char c) {
+  if (c == 'A' || c == 'B' || c == 'C' || c == 'D' || c == 'E' ||
+      c == 'F' || c == 'G' || c == 'H' || c == 'I' || c == 'J' ||
+      c == 'K' || c == 'L' || c == 'M' || c == 'N' || c == 'O' ||
+      c == 'P' || c == 'Q' || c == 'R' || c == 'S' || c == 'T' ||
+      c == 'U' || c == 'V' || c == 'W' || c == 'X' || c == 'Y' ||
+      c == 'Z') {
+    return true;
+  }
+  return false;
+}
+
+// Returns true if c is a lowercase letter (a-z)
+func bool isLower(char c) {
+  if (c == 'a' || c == 'b' || c == 'c' || c == 'd' || c == 'e' ||
+      c == 'f' || c == 'g' || c == 'h' || c == 'i' || c == 'j' ||
+      c == 'k' || c == 'l' || c == 'm' || c == 'n' || c == 'o' ||
+      c == 'p' || c == 'q' || c == 'r' || c == 's' || c == 't' ||
+      c == 'u' || c == 'v' || c == 'w' || c == 'x' || c == 'y' ||
+      c == 'z') {
+    return true;
+  }
+  return false;
+}
+
+// Returns true if c is a digit (0-9)
+func bool isDigit(char c) {
+  if (c == '0' || c == '1' || c == '2' || c == '3' || c == '4' ||
+      c == '5' || c == '6' || c == '7' || c == '8' || c == '9') {
+    return true;
+  }
+  return false;
+}
+
+// Returns true if c is a special character
+func bool isSpecial(char c) {
+  if (isUpper(c) == false && isLower(c) == false && isDigit(c) == false) {
+    return true;
+  }
+  return false;
+}
+
+// Returns true if the username is valid
+func bool isValidUsername(string uname, int len) {
+  local var bool hasUpper = false;
+  local var bool hasLower = false;
+  local var bool hasDigit = false;
+  local var bool hasSpecial = false;
+  local var int i = 0;
+
+  if (len < 8) {
+    return false;
+  }
+
+  for (i = 0; i < len; i += 1) {
+    if (isUpper(uname[i]) == true) {
+      hasUpper = true;
+    }
+    if (isLower(uname[i]) == true) {
+      hasLower = true;
+    }
+    if (isDigit(uname[i]) == true) {
+      hasDigit = true;
+    }
+    if (isSpecial(uname[i]) == true) {
+      hasSpecial = true;
+    }
+  }
+
+  return hasUpper && hasLower && hasDigit && hasSpecial;
+}
+
+int main() {
+  local var string uname = "";
+  local var int len = 0;
+  local var bool valid = false;
+
+  do {
+    thread("Enter username: ");
+    trap(uname);
+
+    thread("Enter username length: ");
+    trap(len);
+
+    valid = isValidUsername(uname, len);
+
+    if (valid == false) {
+      threadln("Invalid username!");
+      threadln("Requirements:");
+      threadln("- At least 8 characters");
+      threadln("- At least 1 uppercase letter");
+      threadln("- At least 1 lowercase letter");
+      threadln("- At least 1 digit");
+      threadln("- At least 1 special character");
+      threadln("Please try again.");
+    }
+  } while (valid == false);
+
+  threadln("Valid username accepted: " .. uname);
+  return 0;
+}

--- a/semantic-backend/semantic/semantic_analyzer.py
+++ b/semantic-backend/semantic/semantic_analyzer.py
@@ -1396,18 +1396,28 @@ class SemanticAnalyzer:
                     )
 
                 if indices:
-                    if not sym.is_array:
+                    if sym.is_array:
+                        if len(indices) != len(sym.dims):
+                            self._err(
+                                f"Array '{tname}' has {len(sym.dims)} dimension(s) "
+                                f"but {len(indices)} index/indices provided",
+                                line, col,
+                            )
+                            return
+                        for i, idx in enumerate(indices):
+                            self._check_index(tname, idx, i, sym.dims, line, col)
+                    elif sym.dtype == "string":
+                        if len(indices) != 1:
+                            self._err(
+                                f"String '{tname}' supports exactly 1 index, "
+                                f"but {len(indices)} index/indices provided",
+                                line, col,
+                            )
+                            return
+                        self._check_index(tname, indices[0], 0, [], line, col)
+                    else:
                         self._err(f"'{tname}' is not an array", line, col)
                         return
-                    if len(indices) != len(sym.dims):
-                        self._err(
-                            f"Array '{tname}' has {len(sym.dims)} dimension(s) "
-                            f"but {len(indices)} index/indices provided",
-                            line, col,
-                        )
-                        return
-                    for i, idx in enumerate(indices):
-                        self._check_index(tname, idx, i, sym.dims, line, col)
                 elif member:
                     weave_sym = self._global.lookup(sym.dtype)
                     if weave_sym is None or not weave_sym.is_weave:
@@ -1482,7 +1492,7 @@ class SemanticAnalyzer:
                             f"Array index cannot be negative (got {iv})",
                             line, col,
                         )
-                    elif dim_pos < len(dims) and iv >= dims[dim_pos]:
+                    elif dims and dim_pos < len(dims) and iv >= dims[dim_pos]:
                         self._err(
                             f"Index {iv} out of bounds for '{arr_name}' "
                             f"(declared size {dims[dim_pos]})",
@@ -1577,19 +1587,31 @@ class SemanticAnalyzer:
             return "unknown"
 
         if indices:
-            if not sym.is_array:
-                self._err(f"'{name}' is not an array", line, col)
-                return "unknown"
-            if len(indices) != len(sym.dims):
-                self._err(
-                    f"Array '{name}' has {len(sym.dims)} dimension(s) "
-                    f"but {len(indices)} index/indices provided",
-                    line, col,
-                )
-                return "unknown"
-            for i, idx in enumerate(indices):
-                self._check_index(name, idx, i, sym.dims, line, col)
-            return sym.dtype
+            if sym.is_array:
+                if len(indices) != len(sym.dims):
+                    self._err(
+                        f"Array '{name}' has {len(sym.dims)} dimension(s) "
+                        f"but {len(indices)} index/indices provided",
+                        line, col,
+                    )
+                    return "unknown"
+                for i, idx in enumerate(indices):
+                    self._check_index(name, idx, i, sym.dims, line, col)
+                return sym.dtype
+
+            if sym.dtype == "string":
+                if len(indices) != 1:
+                    self._err(
+                        f"String '{name}' supports exactly 1 index, "
+                        f"but {len(indices)} index/indices provided",
+                        line, col,
+                    )
+                    return "unknown"
+                self._check_index(name, indices[0], 0, [], line, col)
+                return "char"
+
+            self._err(f"'{name}' is not an array", line, col)
+            return "unknown"
 
         if member:
             weave_sym = self._global.lookup(sym.dtype)


### PR DESCRIPTION
implemented string[index] without changing the lexer or parser, since the existing identifier indexing syntax already parsed forms like name[i]. In the semantic analyzer, we allowed indexed access on scalar string values, required exactly one integer index, inferred the result type as char, and kept ordered char/string comparisons unchanged. In ICG, we updated trap target type inference so trap(name[i]) is treated as a char input target instead of a full string. In the runtime executor, we taught indexed access to read characters from scalar strings and updated trap(string[index]) to rebuild the string by replacing or appending the input character at the requested index.